### PR TITLE
Adding support for nicer metric names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,150 @@
 collectd-iostat-python
 ======================
 
-Collectd-iostat-python is an iostat plugin for collectd that allows you to graph Linux iostat metrics in graphite or other output formats that are supported by collectd.
+`collectd-iostat-python` is an `iostat` plugin for Collectd that allows you to
+graph Linux `iostat` metrics in Graphite or other output formats that are
+supported by Collectd.
 
-This plugin (and mostly this README) is rewrite of [kieran's](https://github.com/keirans/collectd-iostat) [collectd-iostat](https://github.com/keirans/collectd-iostat) in Python and [collectd-python](http://collectd.org/documentation/manpages/collectd-python.5.shtml) instead of Ruby and [collectd-exec](https://collectd.org/documentation/manpages/collectd-exec.5.shtml)
+This plugin (and mostly this `README`) is rewrite of the
+[collectd-iostat](https://github.com/keirans/collectd-iostat) from Ruby to Python
+using the
+[collectd-python](http://collectd.org/documentation/manpages/collectd-python.5.shtml)
+plugin.
 
-Why ?
--------
-Disk performance is quite crucial for most of modern server applications, especially databases. E.g. MySQL - check out [this slides](http://www.percona.com/live/mysql-conference-2013/sessions/monitoring-io-performance-using-iostat-and-pt-diskstats) from Percona Live conference.
 
-Although collectd [provides disk statistics out of the box](https://collectd.org/wiki/index.php/Plugin:Disk), graphing the metrics as shown by iostat was found to be more useful and graphic, because iostat reports usage of block devices, partitions, multipath devices and LVM volumes.
+Why?
+----
 
-Also this plugin was rewritten in Python, because its a preferable language for siteops' tools on my current job, and choice of using [collectd-python](http://collectd.org/documentation/manpages/collectd-python.5.shtml) instead of [collectd-exec](https://collectd.org/documentation/manpages/collectd-exec.5.shtml) was made for performance and stability reasons.
+Disk performance is quite crucial for most of modern server
+applications, especially databases (e.g. MySQL - check out [this
+slides](http://www.percona.com/live/mysql-conference-2013/sessions/monitoring-io-performance-using-iostat-and-pt-diskstats)
+from Percona Live conference).
 
-How ?
--------
-Collectd-iostat-python functions by calling iostat with some predefined intervals and push that data to collectd using collectd-python plugin.
+Although Collectd [provides disk statistics out of the
+box](https://collectd.org/wiki/index.php/Plugin:Disk), graphing the metrics as
+shown by `iostat` was found to be more useful and graphic, because `iostat`
+reports usage of block devices, partitions, multipath devices and LVM volumes.
 
-Collectd can be then configured to write the collected data into many output formats that are supported by it's write plugins, such as graphite, which was the primary use case for this plugin.
+Also this plugin was rewritten in Python, because it's a preferable language for
+siteops' tools on my current job, and choice of using
+[collectd-python](http://collectd.org/documentation/manpages/collectd-python.5.shtml)
+instead of
+[collectd-exec](https://collectd.org/documentation/manpages/collectd-exec.5.shtml)
+was made for performance and stability reasons.
+
+
+How?
+----
+
+`collectd-iostat-python` functions by calling `iostat` with some predefined
+intervals and push that data to Collectd using Collectd `python` plugin.
+
+Collectd can be then configured to write the Collected data into many output
+formats that are supported by it's write plugins, such as `graphite`, which was
+the primary use case for this plugin.
 
 
 Setup
--------
-Deploy the collectd python plugin into a suitable plugin directory for your collectd instance.
+-----
 
-Configure collectd's python plugin to execute the iostat plugin using a stanza similar to the following:
+Deploy the Collectd Python plugin into a suitable plugin directory for your
+Collectd instance.
+
+Configure Collectd's `python` plugin to execute the `iostat` plugin using a
+stanza similar to the following:
 
 
-    <LoadPlugin python>
-        Globals true
-    </LoadPlugin>
+```
+<LoadPlugin python>
+    Globals true
+</LoadPlugin>
 
-    <Plugin python>
-        ModulePath "/usr/lib/collectd/plugins/python"
-        Import "collectd_iostat_python"
+<Plugin python>
+    ModulePath "/usr/lib/collectd/plugins/python"
+    Import "collectd_iostat_python"
 
-        <Module collectd_iostat_python>
-            Path "/usr/bin/iostat"
-            Interval 2
-            Count 2
-            Verbose False
-        </Module>
-    </Plugin>
+    <Module collectd_iostat_python>
+        Path "/usr/bin/iostat"
+        Interval 2
+        Count 2
+        Verbose false
+        NiceNames false
+        PluginName collectd_iostat_python
+    </Module>
+</Plugin>
+```
 
-Once functioning, the iostat data should then be visible via your various output plugins.
+If you would like to use more legible metric names (e.g.
+`requests_merged_per_second-read` instead of `rrqm_s`), you have to set
+`NiceNames` to `true` and add load the custom types database (see the
+`iostat_types.db` file) by adding the following into the Collectd config file:
 
-In the case of Graphite, collectd should be writing data to graphite in the *hostname_domain_tld.collectd_iostat_python.DEVICE.column-name* style namespaces.
-Symbols like '/','-' and '%' in metric names (but not in device names) automatically replacing by underscores (i.e. '_')
- 
-Please note that plugin will take only last line of iostat output, so big Count numbers also have no sense, but Count needs to be more than 1 to get actual and not historical data. And please make Interval * Count << Collectd.INTERVAL (20 seconds by default). I found e.g. Count=2 and Interval=2 works quite well for me.
+```
+# The default Collectd types database
+TypesDB "/usr/share/collectd/types.db"
+# The custom types database
+TypesDB "/usr/share/collectd/iostat_types.db"
+```
+
+Once functioning, the `iostat` data should then be visible via your various
+output plugins.
+
+In the case of Graphite, Collectd should be writing data in the
+`hostname_domain_tld.collectd_iostat_python.DEVICE.column-name` style namespaces.
+Symbols like `/`, `-` and `%` in metric names (but not in device names) are
+automatically replaced by underscores (i.e. `_`).
+
+Please note that this plugin will take only last line of `iostat` output, so big
+`Count` numbers also have no sense, but `Count` needs to be more than `1` to get
+actual and not historical data. And please make `Interval * Count <<
+Collectd.INTERVAL` (4 seconds by default). The deafult value of `Count=2` and
+`Interval=2` works quite well for me.
 
 
 Technical notes
--------
-For parsing iostat output I'm using [jakamkon's](https://bitbucket.org/jakamkon) [python-iostat](https://bitbucket.org/jakamkon/python-iostat) python module, but as internal part of script instead of separate module because of couple of fixes - using Kbytes instead of blocks, adding -N to iostat for LVM endpoint resolving, migration to subprocess module as replacement of deprecated popen3, objectification etc.
+---------------
+
+For parsing `iostat` output, I'm using
+[jakamkon's](https://bitbucket.org/jakamkon)
+[python-iostat](https://bitbucket.org/jakamkon/python-iostat) Python module, but
+as an internal part of the script instead of a separate module because of couple
+of fixes I have made (using Kbytes instead of blocks, adding -N to `iostat` for
+LVM endpoint resolving, migration to `subprocess` module as replacement of
+deprecated `popen3`, `objectification` etc).
 
 
 Compatibility
--------
-Plugin was tested on Ubuntu 12.04/14.04 (collectd 5.2/5.3/5.4, python 2.7) and CentOS (collectd 5.4 / python 2.6). Please note that if running python 2.6 or older (i.e. on CentOS and its derivatives) we trying to restore SIGCHLD signal handler to mitigate [this bug](http://bugs.python.org/issue1731717) and according to [collectd documentation](https://collectd.org/documentation/manpages/collectd-python.5.shtml#configuration) it will break collectd exec plugin, unfortunately.
+-------------
 
+Plugin was tested on Ubuntu 12.04/14.04 (Collectd 5.2/5.3/5.4, Python 2.7) and
+CentOS (Collectd 5.4 / Python 2.6). Please note that if running Python 2.6 or
+older (i.e. on CentOS and its derivatives) we trying to restore `SIGCHLD` signal
+handler to mitigate a known [bug](http://bugs.python.org/issue1731717) which
+according to the Collectd's
+[documentation](https://collectd.org/documentation/manpages/collectd-python.5.shtml#configuration)
+breaks the `exec` plugin, unfortunately.
 
 
 TODO
--------
-Maybe some data aggregation needed, e.g. we can use some max / avg aggregation of data across intervals instead of picking last line of iostat output.
+----
+
+* Maybe some data aggregation needed (e.g. we can use some max / avg aggregation
+of data across intervals instead of picking last line of `iostat` output).
+* The `Disks` parameter could support regexp.
 
 
 Additional reading
--------
+------------------
+
 * [man iostat(1)](http://linux.die.net/man/1/iostat)
-
 * [Custom Collectd Plug-ins for Linux](http://support.rightscale.com/12-Guides/RightScale_101/08-Management_Tools/Monitoring_System/Writing_custom_collectd_plugins/Custom_Collectd_Plug-ins_for_Linux)
-
 * [python-iostat](https://bitbucket.org/jakamkon/python-iostat)
-
 * [collectd-iostat](https://github.com/keirans/collectd-iostat)
-
 * [Graphite @ The Architecture of Open Source Applications](http://www.aosabook.org/en/graphite.html)
+
 
 Contact
 -------
-[@deniszh](http://twitter.com/deniszh) || [Email - Denis Zhdanov](mailto:denis.zhdanov@gmail.com)
+
+[Denis Zhdanov](mailto:denis.zhdanov@gmail.com)
+([@deniszh](http://twitter.com/deniszh))

--- a/collectd_iostat_python.py
+++ b/collectd_iostat_python.py
@@ -1,44 +1,49 @@
 #!/usr/bin/env python
 # coding=utf-8
 #
-#  collectd-iostat-python
-# ========================
+# collectd-iostat-python
+# ======================
 #
-# Collectd-iostat-python is an iostat plugin for collectd that allows you to graph Linux iostat metrics in Graphite
-# or other output formats that are supported by collectd.
+# Collectd-iostat-python is an iostat plugin for collectd that allows you to
+# graph Linux iostat metrics in Graphite or other output formats that are
+# supported by collectd.
 #
-# https://github.com/powdahound/redis-collectd-plugin - was used as template
-# https://github.com/keirans/collectd-iostat/ - was used as inspiration
-# contains some code from
-# https://bitbucket.org/jakamkon/python-iostat by Kuba Kończyk <jakamkon at users.sourceforge.net>
+# https://github.com/powdahound/redis-collectd-plugin
+#   - was used as template
+# https://github.com/keirans/collectd-iostat/
+#   - was used as inspiration and contains some code from
+# https://bitbucket.org/jakamkon/python-iostat
+#   - by Kuba Kończyk <jakamkon at users.sourceforge.net>
 #
 
-__version__ = '0.0.2'
+import signal
+import string
+import subprocess
+import sys
+
+
+__version__ = '0.0.3'
 __author__ = 'denis.zhdanov@gmail.com'
 
-import sys
-import subprocess
-import signal
 
 class IOStatError(Exception):
     pass
 
+
 class CmdError(IOStatError):
     pass
+
 
 class ParseError(IOStatError):
     pass
 
-class IOStat(object):
 
-    def __init__(self, path='/usr/bin/iostat', interval=1, count=10, disks=None):
+class IOStat(object):
+    def __init__(self, path='/usr/bin/iostat', interval=2, count=2, disks=[]):
         self.path = path
         self.interval = interval
         self.count = count
-        if disks:
-            self.disks = disks
-        else:
-            self.disks = []
+        self.disks = disks
 
     def parse_diskstats(self, input):
         """
@@ -56,9 +61,10 @@ class IOStat(object):
         @return: C{dictionary} contains per block device statistics.
         Statistics are in form of C{dictonary}.
         Main statistics:
-        tps   Blk_read/s   Blk_wrtn/s   Blk_read   Blk_wrtn
+          tps  Blk_read/s  Blk_wrtn/s  Blk_read  Blk_wrtn
         Extended staistics (available with post 2.5 kernels):
-        rrqm/s wrqm/s   r/s   w/s  rsec/s  wsec/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
+          rrqm/s  wrqm/s  r/s  w/s  rsec/s  wsec/s  rkB/s  wkB/s  avgrq-sz \
+          avgqu-sz  await  svctm  %util
         See I{man iostat} for more details.
         """
         dstats = {}
@@ -75,6 +81,7 @@ class IOStat(object):
                 dev = d.pop(0)
                 if (dev in self.disks) or not self.disks:
                     dstats[dev] = dict([(k, float(v)) for k, v in zip(hdr, d)])
+
         return dstats
 
     def sum_dstats(self, stats, smetrics):
@@ -82,6 +89,7 @@ class IOStat(object):
         Compute the summary statistics for chosen metrics.
         """
         avg = {}
+
         for disk, metrics in stats.iteritems():
             for mname, metric in metrics.iteritems():
                 if mname not in smetrics:
@@ -90,6 +98,7 @@ class IOStat(object):
                     avg[mname] += metric
                 else:
                     avg[mname] = metric
+
         return avg
 
     def _run(self, options=None):
@@ -97,8 +106,19 @@ class IOStat(object):
         Run iostat command.
         """
         close_fds = 'posix' in sys.builtin_module_names
-        args = '%s %s %s %s %s' % (self.path, ''.join(options), self.interval, self.count, ' '.join(self.disks))
-        return subprocess.Popen(args, bufsize=1, shell=True, stdout=subprocess.PIPE, close_fds=close_fds)
+        args = '%s %s %s %s %s' % (
+            self.path,
+            ''.join(options),
+            self.interval,
+            self.count,
+            ' '.join(self.disks))
+
+        return subprocess.Popen(
+            args,
+            bufsize=1,
+            shell=True,
+            stdout=subprocess.PIPE,
+            close_fds=close_fds)
 
     @staticmethod
     def _get_childs_data(child):
@@ -107,8 +127,10 @@ class IOStat(object):
         """
         (stdout, stderr) = child.communicate()
         ecode = child.poll()
+
         if ecode != 0:
             raise CmdError('Command %r returned %d' % (child.cmd, ecode))
+
         return stdout
 
     def get_diskstats(self):
@@ -121,57 +143,117 @@ class IOStat(object):
         edd = self._get_childs_data(extdstats)
         ds = self.parse_diskstats(dsd)
         eds = self.parse_diskstats(edd)
+
         for dk, dv in ds.iteritems():
             if dk in eds:
                 ds[dk].update(eds[dk])
+
         return ds
 
 
 class IOMon(object):
-
     def __init__(self):
         self.plugin_name = 'collectd-iostat-python'
         self.iostat_path = '/usr/bin/iostat'
         self.iostat_interval = 2
         self.iostat_count = 2
         self.iostat_disks = []
+        self.iostat_nice_names = False
+        self.iostat_disks_regex = ''
         self.verbose_logging = False
+        self.names = {
+            'tps': {'t': 'transfers_per_second'},
+            'Blk_read/s': {'t': 'blocks_per_second', 'ti': 'read'},
+            'kB_read/s': {'t': 'bytes_per_second', 'ti': 'read', 'm': 10e3},
+            'MB_read/s': {'t': 'bytes_per_second', 'ti': 'read', 'm': 10e6},
+            'Blk_wrtn/s': {'t': 'blocks_per_second', 'ti': 'write'},
+            'kB_wrtn/s': {'t': 'bytes_per_second', 'ti': 'write', 'm': 10e3},
+            'MB_wrtn/s': {'t': 'bytes_per_second', 'ti': 'write', 'm': 10e6},
+            'Blk_read': {'t': 'blocks', 'ti': 'read'},
+            'kB_read': {'t': 'bytes', 'ti': 'read', 'm': 10e3},
+            'MB_read': {'t': 'bytes', 'ti': 'read', 'm': 10e6},
+            'Blk_wrtn': {'t': 'blocks', 'ti': 'write'},
+            'kB_wrtn': {'t': 'bytes', 'ti': 'write', 'm': 10e3},
+            'MB_wrtn': {'t': 'bytes', 'ti': 'write', 'm': 10e6},
+            'rrqm/s': {'t': 'requests_merged_per_second', 'ti': 'read'},
+            'wrqm/s': {'t': 'requests_merged_per_second', 'ti': 'write'},
+            'r/s': {'t': 'per_second', 'ti': 'read'},
+            'w/s': {'t': 'per_second', 'ti': 'write'},
+            'rsec/s': {'t': 'sectors_per_second', 'ti': 'read'},
+            'rkB/s': {'t': 'bytes_per_second', 'ti': 'read', 'm': 10e3},
+            'rMB/s': {'t': 'bytes_per_second', 'ti': 'read', 'm': 10e6},
+            'wsec/s': {'t': 'sectors_per_second', 'ti': 'write'},
+            'wkB/s': {'t': 'bytes_per_second', 'ti': 'write', 'm': 10e3},
+            'wMB/s': {'t': 'bytes_per_second', 'ti': 'write', 'm': 10e6},
+            'avgrq-sz': {'t': 'avg_request_size'},
+            'avgqu-sz': {'t': 'avg_request_queue'},
+            'await': {'t': 'avg_wait_time'},
+            'r_await': {'t': 'avg_wait_time', 'ti': 'read'},
+            'w_await': {'t': 'avg_wait_time', 'ti': 'write'},
+            'svctm': {'t': 'avg_service_time'},
+            '%util': {'t': 'percent', 'ti': 'util'}
+        }
 
     def log_verbose(self, msg):
         if not self.verbose_logging:
             return
-        collectd.info('collectd-iostat-python plugin [verbose]: %s' % msg)
+        collectd.info('%s plugin [verbose]: %s' % (self.plugin_name, msg))
 
     def configure_callback(self, conf):
         """
         Receive configuration block
         """
         for node in conf.children:
-            if node.key == 'Path':
-                self.iostat_path = node.values[0]
-            elif node.key == 'Interval':
-                self.iostat_interval = int(node.values[0])
-            elif node.key == 'Count':
-                self.iostat_count = int(node.values[0])
-            elif node.key == 'Disks':
-                self.iostat_disks = str(node.values[0]).split(',')
-            elif node.key == 'Verbose':
-                self.verbose_logging = str(node.values[0]) == 'True'
-            else:
-                collectd.warning('collectd-iostat-python plugin: Unknown config key: %s.' % node.key)
-        self.log_verbose('Configured with iostat=%s, interval=%s, count=%s, disks=%s' %
-                         (self.iostat_path, self.iostat_interval, self.iostat_count, self.iostat_disks))
+            val = str(node.values[0])
 
-    def dispatch_value(self, plugin_instance, value_type, instance, value):
+            if node.key == 'Path':
+                self.iostat_path = val
+            elif node.key == 'Interval':
+                self.iostat_interval = int(float(val))
+            elif node.key == 'Count':
+                self.iostat_count = int(float(val))
+            elif node.key == 'Disks':
+                self.iostat_disks = val.split(',')
+            elif node.key == 'NiceNames':
+                self.iostat_nice_names = val in ['True', 'true']
+            elif node.key == 'DisksRegex':
+                self.iostat_disks_regex = val
+            elif node.key == 'PluginName':
+                self.plugin_name = val
+            elif node.key == 'Verbose':
+                self.verbose_logging = val in ['True', 'true']
+            else:
+                collectd.warning(
+                    '%s plugin: Unknown config key: %s.' % (
+                        self.plugin_name,
+                        node.key))
+
+        self.log_verbose(
+            'Configured with iostat=%s, interval=%s, count=%s, disks=%s, '
+            'disks_regex=%s' % (
+                self.iostat_path,
+                self.iostat_interval,
+                self.iostat_count,
+                self.iostat_disks,
+                self.iostat_disks_regex))
+
+    def dispatch_value(self, plugin_instance, val_type, type_instance, value):
         """
         Dispatch a value to collectd
         """
-        self.log_verbose('Sending value: %s.%s.%s=%s' % (self.plugin_name, plugin_instance, instance, value))
+        self.log_verbose(
+            'Sending value: %s-%s.%s=%s' % (
+                self.plugin_name,
+                plugin_instance,
+                '-'.join([val_type, type_instance]),
+                value))
+
         val = collectd.Values()
         val.plugin = self.plugin_name
         val.plugin_instance = plugin_instance
-        val.type = value_type
-        val.type_instance = instance
+        val.type = val_type
+        if len(type_instance):
+            val.type_instance = type_instance
         val.values = [value, ]
         val.dispatch()
 
@@ -180,16 +262,39 @@ class IOMon(object):
         Collectd read callback
         """
         self.log_verbose('Read callback called')
-        iostat = IOStat(path=self.iostat_path, interval=self.iostat_interval,
-                count=self.iostat_count, disks=self.iostat_disks)
+        iostat = IOStat(
+            path=self.iostat_path,
+            interval=self.iostat_interval,
+            count=self.iostat_count,
+            disks=self.iostat_disks)
         ds = iostat.get_diskstats()
+
         if not ds:
-            self.log_verbose('collectd-iostat-python plugin: No info received.')
+            self.log_verbose('%s plugin: No info received.' % self.plugin_name)
             return
-        for disk in ds.keys():
-            for metric in ds[disk]:
-                metric_name = metric.replace('/', '_').replace('-', '_').replace('%', '_')
-                self.dispatch_value(disk, 'gauge', metric_name, ds[disk][metric])
+
+        for disk in ds:
+            for name in ds[disk]:
+                if self.iostat_nice_names and name in self.names:
+                    val_type = self.names[name]['t']
+
+                    if 'ti' in self.names[name]:
+                        type_instance = self.names[name]['ti']
+                    else:
+                        type_instance = ''
+
+                    value = ds[disk][name]
+                    if 'm' in self.names[name]:
+                        value *= self.names[name]['m']
+                else:
+                    val_type = 'gauge'
+                    tbl = string.maketrans('/-%', '___')
+                    type_instance = name.translate(tbl)
+                    value = ds[disk][name]
+
+                self.dispatch_value(
+                    disk, val_type, type_instance, value)
+
 
 def restore_sigchld():
     """
@@ -198,20 +303,26 @@ def restore_sigchld():
     See https://github.com/deniszh/collectd-iostat-python/issues/2 for details
     """
     if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-       signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+
 
 if __name__ == '__main__':
-    iostat = IOStat(interval=2, count=2)
+    iostat = IOStat()
     ds = iostat.get_diskstats()
-    for disk in ds.keys():
+
+    for disk in ds:
         for metric in ds[disk]:
-            metric_name = metric.replace('/', '_').replace('-', '_').replace('%', '_')
-            print "%s.%s:%s" % (disk, metric_name, ds[disk][metric])
+            tbl = string.maketrans('/-%', '___')
+            metric_name = metric.translate(tbl)
+            print("%s.%s:%s" % (disk, metric_name, ds[disk][metric]))
+
     sys.exit(0)
 else:
     import collectd
+
     iomon = IOMon()
-    # register callbacks
+
+    # Register callbacks
     collectd.register_init(restore_sigchld)
     collectd.register_config(iomon.configure_callback)
     collectd.register_read(iomon.read_callback)

--- a/iostat_types.db
+++ b/iostat_types.db
@@ -1,0 +1,11 @@
+avg_request_queue           value:GAUGE:0:U
+avg_request_size            value:GAUGE:0:U
+avg_service_time            value:GAUGE:0:U
+avg_wait_time               value:GAUGE:0:U
+blocks                      value:GAUGE:0:U
+blocks_per_second           value:GAUGE:0:U
+bytes_per_second            value:GAUGE:0:U
+transfers_per_second        value:GAUGE:0:U
+per_second                  value:GAUGE:0:U
+requests_merged_per_second  value:GAUGE:0:U
+sectors_per_second          value:GAUGE:0:U


### PR DESCRIPTION
This patch is adding a support for nicer metric names by translating the
default abbreviated names into fully described names. That allows to define
proper Collectd types and instead of the generic `gauge` type. Metric
with possibility of having different unit size are recalculated and unified
to their smallest possible unit (e.g. `kB_read/s` or `MB_read/s` becomes
`bytes_per_second-read`).

Apart of this main feature, additional parameter called `PluginName` was
introduced to add the possibility to change the plugin name to something
shorter (e.g. `iostat`). The whole code was also reviewed and made compliant
with PEP8 style guide.
