### PR TITLE
Add persistent naming option based on udev attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ TypesDB "/usr/share/collectd/types.db"
 TypesDB "/usr/share/collectd/iostat_types.db"
 ```
 
+In large and changing environments it benefital if your device statistics maintain the same device names across reboots or reconfigurations so that historical data is not compromised. This can be achived by enabling persistent naming based on udev attributes.
+Simply enable persistent naming by setting UdevNameAttr to the attribute you want to use to name your devices. A good example would be ID_SERIAL which is persistent and unique per device. To find useful attributes you can use `udevadm info /dev/<devicename>`
+```
+# Enable persistent device naming
+UdevNameAttr "ID_SERIAL"
+```
+
 Once functioning, the `iostat` data should then be visible via your various
 output plugins. Please note, that you need to restart collectd service after
 plugin installation, as usual.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ stanza similar to the following:
 </Plugin>
 ```
 
+If you need to select a subset of the devices listed by iostat you can utilize 
+`DisksRegex` to write a regular expression to select the appropriate devices for your environment.
+```
+# Only collect data for these devices
+DisksRegex "^[hs]d"
+```
+
+In large and changing environments it benefital if your device statistics maintain the same device names across reboots or reconfigurations so that historical data is not compromised. This can be achived by enabling persistent naming based on udev attributes.
+Simply enable persistent naming by setting UdevNameAttr to the attribute you want to use to name your devices. A good example would be ID_SERIAL which is persistent and unique per device. To find useful attributes you can use `udevadm info /dev/<devicename>`
+```
+# Enable persistent device naming
+UdevNameAttr "ID_SERIAL"
+```
+
 If you would like to use more legible metric names (e.g.
 `requests_merged_per_second-read` instead of `rrqm_s`), you have to set
 `NiceNames` to `true` and add load the custom types database (see the
@@ -84,13 +98,6 @@ If you would like to use more legible metric names (e.g.
 TypesDB "/usr/share/collectd/types.db"
 # The custom types database
 TypesDB "/usr/share/collectd/iostat_types.db"
-```
-
-In large and changing environments it benefital if your device statistics maintain the same device names across reboots or reconfigurations so that historical data is not compromised. This can be achived by enabling persistent naming based on udev attributes.
-Simply enable persistent naming by setting UdevNameAttr to the attribute you want to use to name your devices. A good example would be ID_SERIAL which is persistent and unique per device. To find useful attributes you can use `udevadm info /dev/<devicename>`
-```
-# Enable persistent device naming
-UdevNameAttr "ID_SERIAL"
 ```
 
 Once functioning, the `iostat` data should then be visible via your various

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ stanza similar to the following:
 </Plugin>
 ```
 
+If you need to select a subset of the devices listed by iostat you can utilize 
+`DisksRegex` to write a regular expression to select the appropriate devices for your environment.
+```
+# Only collect data for these devices
+DisksRegex "^[hs]d"
+```
+
 If you would like to use more legible metric names (e.g.
 `requests_merged_per_second-read` instead of `rrqm_s`), you have to set
 `NiceNames` to `true` and add load the custom types database (see the

--- a/collectd_iostat_python.py
+++ b/collectd_iostat_python.py
@@ -20,6 +20,7 @@ import signal
 import string
 import subprocess
 import sys
+import re
 
 
 __version__ = '0.0.3'
@@ -280,6 +281,8 @@ class IOMon(object):
             return
 
         for disk in ds:
+            if not re.match(self.iostat_disks_regex, disk):
+                continue
             for name in ds[disk]:
                 if self.iostat_nice_names and name in self.names:
                     val_type = self.names[name]['t']

--- a/collectd_iostat_python.py
+++ b/collectd_iostat_python.py
@@ -20,6 +20,7 @@ import signal
 import string
 import subprocess
 import sys
+import re
 import pyudev
 
 
@@ -286,6 +287,8 @@ class IOMon(object):
 
         context = pyudev.Context()
         for disk in ds:
+            if not re.match(self.iostat_disks_regex, disk):
+                continue
             for name in ds[disk]:
                 if self.iostat_nice_names and name in self.names:
                     val_type = self.names[name]['t']


### PR DESCRIPTION
In larger environments using /dev/sdX device naming can change over time and make historical data useless.
This patch enables device naming based on device attributes extracted using udev. 
In turn this mean that you can get persistent naming by leveraging attributes such as ID_SERIAL (disk serial #).