### PR TITLE
Add support for ignoring the inactive disk in a DM multipath setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ stanza similar to the following:
         Verbose false
         NiceNames false
         PluginName collectd_iostat_python
+        IgnoreInactiveMultipath false
     </Module>
 </Plugin>
 ```
@@ -87,6 +88,14 @@ Simply enable persistent naming by setting UdevNameAttr to the attribute you wan
 # Enable persistent device naming
 UdevNameAttr "ID_SERIAL"
 ```
+
+In a multipath disk environment, iostat will see both paths to a physical disk as distinct /dev entries. Sending statistics for those disks, when UdevNameAttr is enabled, can cause incorrect stats for a physical disk to be sent. Enabling IgnoreInactiveMultipath will only processes active disks in a DM multipath environment. 
+
+```
+# Skip inactive multipath disks
+IgnoreInactiveMultipath true
+```
+
 Please note that you need to install [pyudev](https://pyudev.readthedocs.io/en/latest/) Python module for this functionality.
 
 

--- a/collectd_iostat_python.py
+++ b/collectd_iostat_python.py
@@ -300,11 +300,11 @@ class IOMon(object):
                 continue
             if self.iostat_udevnameattr and pyudev_available:
                 device = pyudev.Device.from_device_file(context, "/dev/" + disk)
-                '''
+                """ 
                 SCSI_IDENT_PORT_RELATIVE value of 2 indicates the disk is the
                 active path in a multipath environment. A value of 1 indicates
                 that it is the backup path.
-                '''
+                """ 
                 if self.multipath:
                     relative = device.get('SCSI_IDENT_PORT_RELATIVE')
                     mp_managed = device.get('DM_MULTIPATH_DEVICE_PATH')


### PR DESCRIPTION
We have a mixed multipath / non-multipath environment. Gathering statistics in this environment is challenging. If we simply process only the resolved multipath names (350xx) then we miss all the single-pathed devices. If we process all /dev/sdX disks when extracting a udev name (in our case ID_VDEV), the behavior is inconsistent between runs. Checking if a disk is managed by multipathd via DM_MULTIPATH_DEVICE_PATH then enables us to determine the active and backup disk path via 
SCSI_IDENT_PORT_RELATIVE . 

We can now use ID_VDEV as a device name in a mixed single and multipath environment.

Example values extracted from a system:

List the two disks backing a dm device
```
# multipath -l | tail -6
35000c50057cf78d7 dm-47 SEAGATE,ST2000NM0023
size=1.8T features='0' hwhandler='0' wp=rw
|-+- policy='round-robin 0' prio=0 status=active
| `- 0:0:82:0  sdcb 68:240  active undef running
`-+- policy='round-robin 0' prio=0 status=enabled
  `- 7:0:82:0  sdfn 130:144 active undef running
```

This is the inactive disk
```
# udevadm info -q all /dev/sdfn | egrep '(SCSI_IDENT_PORT_RELATIVE|DM_MULTIPATH)'
E: DM_MULTIPATH_DEVICE_PATH=1
E: SCSI_IDENT_PORT_RELATIVE=1
```

This is the active disk
```
# udevadm info -q all /dev/sdcb | egrep '(SCSI_IDENT_PORT_RELATIVE|DM_MULTIPATH)'
E: DM_MULTIPATH_DEVICE_PATH=1
E: SCSI_IDENT_PORT_RELATIVE=2
```

Verify that the inactive disk was skipped
```
# tail -f /var/log/syslog | grep sdfn
May 17 10:27:42 ##### collectd[2434]: disks plugin [verbose]: Skipping inactive disk sdfn
```
