### PR TITLE
Add multipath logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Simply enable persistent naming by setting UdevNameAttr to the attribute you wan
 # Enable persistent device naming
 UdevNameAttr "ID_SERIAL"
 ```
+
+Please note that you need to install [pyudev](https://pyudev.readthedocs.io/en/latest/) Python module for this functionality.
+
+In a multipath environment, a single physical disk can be exposed as two /dev entries. A device mapper entry is created by multipathd to handle interacting with the disk. Setting SkipPhysicalMultipath causes the physical multipath disks to be skipped, and only the dm- entry to be processed. Physical non-multipathed disks will be processed normally. Enable NoDisplayDMName as well to display the /dev entry instead of the registered device name.
+
+```
+SkipPhysicalMultipath true
+NoDisplayDMName true
+```
+
 Please note that you need to install [pyudev](https://pyudev.readthedocs.io/en/latest/) Python module for this functionality.
 
 


### PR DESCRIPTION
Add a toggle to remove 'N' from the iostat options, which forces device mapper disks to show as their dm- name.

Add a toggle to skip physical disks part of a multipath setup. This option causes DM_MULTIPATH_DEVICE_PATH to be evaluated. If it has a value of '1', the disk is a physical disk part of a multipath disk configuration, and is skipped.

This allows us to evaluate dm- devices and get combined/correct stats for round-robin multipath disks. 

pyudev is required for this to function correctly. 

The code to lookup a specific/persistent udev name attribute was moved and is now evaluated once per disk, instead of once per iostat column.