### PR TITLE
Fix for removed trailing colon in output of latest iostat versions

### DIFF
--- a/collectd_iostat_python.py
+++ b/collectd_iostat_python.py
@@ -75,7 +75,7 @@ class IOStat(object):
         See I{man iostat} for more details.
         """
         dstats = {}
-        dsi = input.rfind('Device:')
+        dsi = input.rfind('Device')
         if dsi == -1:
             raise ParseError('Unknown input format: %r' % input)
 


### PR DESCRIPTION
Change in iostat code: https://github.com/sysstat/sysstat/commit/754d68088c1e27d8a19ea8d82b69e3bb479a07ac